### PR TITLE
Update docker tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ curl https://raw.githubusercontent.com/HyperLink-Technology/brownie/master/brown
 To build the image:
 
 ```bash
-docker build https://github.com/HyperLink-Technology/brownie.git -t brownie:1
+docker build https://github.com/HyperLink-Technology/brownie.git -t brownie
 ```
 
 You can then run brownie with:


### PR DESCRIPTION
If you have "brownie:1" in the build command, the image that results is tagged as brownie:1.

The run command doesn't specify brownie:1 so docker looks for brownie:latest, which doesn't exist.  This PR removes the 1. Alternately you could add the :1 to the run command.