### PR TITLE
Rpc

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 1.0.0b4
 -------
 
+ - Detect and attach to an already active RPC client, better verbosity on RPC exceptions
  - introduce Singleton metaclass and refactor code to take advantage
  - add EventDict and EventItem classes for transaction event logs
  - cli.color, add _print_as_dict _print_as_list _dir_color attributes

--- a/brownie/exceptions.py
+++ b/brownie/exceptions.py
@@ -14,6 +14,31 @@ class ExpectedFailing(Exception):
     pass
 
 
+class _RPCBaseException(Exception):
+
+    def __init__(self, msg, cmd, proc, uri):
+        code = proc.poll()
+        out = proc.stdout.read().decode().strip() or "  (Empty)"
+        err = proc.stderr.read().decode().strip() or "  (Empty)"
+        super().__init__(
+            "{}\n\nCommand: {}\nURI: {}\nExit Code: {}\n\nStdout:\n{}\n\nStderr:\n{}".format(
+                msg, cmd, uri, code, out, err
+            )
+        )
+
+class RPCProcessError(_RPCBaseException):
+
+    def __init__(self, cmd, proc, uri):
+        super().__init__("Unable to launch local RPC client.", cmd, proc, uri)
+
+
+class RPCConnectionError(_RPCBaseException):
+
+    def __init__(self, cmd, proc, uri):
+        super().__init__("Able to launch RPC client, but unable to connect.", cmd, proc, uri)
+
+
+
 class VirtualMachineError(Exception):
 
     '''Raised when a call to a contract causes an EVM exception.

--- a/brownie/network/__init__.py
+++ b/brownie/network/__init__.py
@@ -38,17 +38,25 @@ def connect(network=None):
             )
         web3.connect(CONFIG['active_network']['host'])
         if 'test-rpc' in CONFIG['active_network'] and not rpc.is_active():
-            rpc.launch(CONFIG['active_network']['test-rpc'])
+            if is_connected():
+                if web3.eth.blockNumber != 0:
+                    raise ValueError("Local RPC Client has a block height > 0")
+                rpc.attach(CONFIG['active_network']['host'])
+            else:
+                rpc.launch(CONFIG['active_network']['test-rpc'])
     except Exception:
         CONFIG['active_network']['name'] = None
         raise
 
 
 def disconnect():
-    '''Disconnects from the network'''
+    '''Disconnects from the network.'''
     web3.disconnect()
     if rpc.is_active():
-        rpc.kill()
+        if rpc.is_child():
+            rpc.kill()
+        else:
+            rpc.reset()
     CONFIG['active_network']['name'] = None
 
 

--- a/brownie/network/rpc.py
+++ b/brownie/network/rpc.py
@@ -149,11 +149,18 @@ class Rpc(metaclass=_Singleton):
         return id_
 
     def is_active(self):
+        '''Returns True if Rpc client is currently active.'''
         if not self._rpc:
             return False
         if type(self._rpc) is psutil.Popen:
             self._rpc.poll()
         return self._rpc.is_running()
+
+    def is_child(self):
+        '''Returns True if the Rpc client is active and was launched by Brownie.'''
+        if not is_active():
+            return False
+        return self._rpc.parent() == psutil.Process()
 
     def time(self):
         '''Returns the current epoch time from the test RPC as an int'''

--- a/docs/api-brownie.rst
+++ b/docs/api-brownie.rst
@@ -28,6 +28,14 @@ The ``exceptions`` module contains all Brownie ``Exception`` classes.
 
     Raised when a unit test is marked as ``pending=True`` but it still passes.
 
+.. py:exception:: RPCConnectionError
+
+    Raised when the RPC process is active and ``web3`` is connected, but Brownie is unable to communicate with it.
+
+.. py:exception:: RPCProcessError
+
+    Raised when the RPC process fails to launch successfully.
+
 .. py:exception:: VirtualMachineError
 
     Raised when a call to the EVM reverts.

--- a/docs/interaction.rst
+++ b/docs/interaction.rst
@@ -12,7 +12,7 @@ The console feels very similar to a regular python interpreter. From inside a pr
 
     $ brownie console
 
-Brownie will compile the contracts, start the local RPC, and then give you a command prompt. From here you may interact with the network with the full range of functionality offered by the :ref:`api`.
+Brownie will compile the contracts, launch or attach to :ref:`test-rpc`, and then give you a command prompt. From here you may interact with the network with the full range of functionality offered by the :ref:`api`.
 
 .. hint::
 

--- a/docs/test-rpc.rst
+++ b/docs/test-rpc.rst
@@ -1,0 +1,119 @@
+.. _test-rpc:
+
+====================
+The Local RPC Client
+====================
+
+Brownie is designed to use `ganache-cli <https://github.com/trufflesuite/ganache-cli>`__ as a local development environment.
+
+Launching and Connecting
+========================
+
+The connection settings for the local RPC are outlined in ``brownie-config.json``:
+
+.. code-block:: javascript
+
+    "development": {
+        "test-rpc": "ganache-cli",
+        "host": "http://127.0.0.1:8545"
+    }
+
+Each time Brownie is loaded, it will first attempt to connect to the ``host`` address to determine if the RPC client is already active.
+
+RPC Client is Active
+---------------------
+
+If able to connect to the ``host`` address, Brownie:
+If Brownie is able to connect at the ``host`` address, the following actions happen during launch:
+
+* Checks the current block height and raises an Exception if it is greater than zero
+* Locates the process listening at the address and attaches it to the ``Rpc`` object
+* Takes a snapshot
+
+When Brownie is terminated:
+
+* The RPC client is reverted based on the initial snapshot.
+
+RPC Client is not Active
+------------------------
+
+If unable to connect to the ``host`` address, Brownie:
+
+* Launches the client using the ``test-rpc`` command given in the configuration file
+* Waits to see that the process loads successfully
+* Confirms that it can connect to the new process
+* Attaches the process to the ``Rpc`` object
+
+When Brownie is terminated:
+
+* The RPC client and any child processes are also terminated.
+
+Common Interactions
+===================
+
+You can interact with the RPC client using the :ref:`rpc` object, which is automatically instantiated as ``rpc``:
+
+.. code-block:: python
+
+    >>> rpc
+    <brownie.network.rpc.Rpc object at 0x7f720f65fd68>
+
+Mining
+------
+
+To mine empty blocks, use ``rpc.mine``.
+
+.. code-block:: python
+
+    >>> web3.eth.blockNumber
+    0
+    >>> rpc.mine(50)
+    Block height at 50
+    >>> web3.eth.blockNumber
+    50
+
+Time
+----
+
+You can call ``rpc.time`` to view the current epoch time. To fast forward, call ``rpc.sleep``.
+
+.. code-block:: python
+
+    >>> rpc.time()
+    1557151189
+    >>> rpc.sleep(100)
+    >>> rpc.time()
+    1557151289
+
+Snapshots
+---------
+
+``rpc.snapshot`` takes a snapshot of the current state of the blockchain. You can return to this state later using ``rpc.revert``.
+
+.. code-block:: python
+
+    >>> rpc.snapshot()
+    Snapshot taken at block height 4
+    >>> accounts[0].balance()
+    100000000000000000000
+    >>> accounts[0].transfer(accounts[1], "10 ether")
+
+    Transaction sent: 0xd5d3b40eb298dfc48721807935eda48d03916a3f48b51f20bcded372113e1dca
+    Transaction confirmed - block: 5   gas used: 21000 (100.00%)
+    <Transaction object '0xd5d3b40eb298dfc48721807935eda48d03916a3f48b51f20bcded372113e1dca'>
+    >>> accounts[0].balance()
+    89999580000000000000
+    >>> rpc.revert()
+    Block height reverted to 4
+    >>> accounts[0].balance()
+    100000000000000000000
+
+To return to the genesis state, use ``rpc.reset``.
+
+.. code-block:: python
+
+    >>> web3.eth.blockNumber
+    6
+    >>> rpc.reset()
+    >>> web3.eth.blockNumber
+    0

--- a/docs/toctree.rst
+++ b/docs/toctree.rst
@@ -15,6 +15,7 @@ Brownie
     debug.rst
     tests.rst
     coverage.rst
+    test-rpc.rst
     config.rst
     python-package.rst
     api.rst

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ eth-hash[pycryptodome]>=0.2.0,<1.0.0
 eth-utils>=1.2.0,<2.0.0
 hexbytes>=0.1.0,<1.0.0
 lru-dict>=1.1.6,<2.0.0
+psutil>=5.6.2
 pypiwin32>=223;platform_system=='Windows'
 pyreadline==2.1;platform_system=='Windows'
 py-solc-x>=0.2.1


### PR DESCRIPTION
### What was wrong / missing?
* Automatically launching the test RPC client was not intuitive behaviour for users who are familiar with Truffle.
* Brownie did not play nicely if the client was already launched.
* There were issues with killing the process on Windows systems.

### How was it fixed / added?
* Check for already active RPC client and attempt to attach to it
* Improved exception verbosity when attaching or connecting fails
* Add new section to docs to explain how it all works


#### Cute Animal Picture

![don't mind if i do](https://featuredcreature.com/wp-content/uploads/2013/04/tumblr_mkxd6dBwDW1qa9omho1_500.jpg)